### PR TITLE
Cate Freezes when Computing min max and data is all NaN

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## Changes in 2.0.0-dev.21 (in development)
 
+* Fix: Cate does not freeze when computing min max on data that is all NaN
 
 ## Changes in 2.0.0-dev.20
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 ## Changes in 2.0.0-dev.21 (in development)
 
-* Fix: Cate does not freeze when computing min max on data that is all NaN
+* Fix: Cate does not freeze when computing min max on data that is all NaN [#797](https://github.com/CCI-Tools/cate/issues/797)
 
 ## Changes in 2.0.0-dev.20
 

--- a/src/renderer/containers/StylesPanel.tsx
+++ b/src/renderer/containers/StylesPanel.tsx
@@ -528,6 +528,11 @@ class StylesPanel extends React.Component<IStylesPanelProps & DispatchProp<State
 
         let min = statistics.min;
         let max = statistics.max;
+
+        if(isNaN(min) || isNaN(max)){
+            return <span style={{color: Colors.ORANGE3}}>All values are NaN</span>;
+        }
+
         if (min === max) {
             return <span style={{color: Colors.ORANGE3}}>All values are {min}</span>;
         }

--- a/src/renderer/containers/StylesPanel.tsx
+++ b/src/renderer/containers/StylesPanel.tsx
@@ -529,7 +529,7 @@ class StylesPanel extends React.Component<IStylesPanelProps & DispatchProp<State
         let min = statistics.min;
         let max = statistics.max;
 
-        if(isNaN(min) || isNaN(max)){
+        if (isNaN(min) || isNaN(max)){
             return <span style={{color: Colors.ORANGE3}}>All values are NaN</span>;
         }
 


### PR DESCRIPTION
'When accepting this PR cate will not freeze anymore when comuting a valid min and max in STLYES when data points
are all NaN.