### PR TITLE
Drawing poly features hampered

### DIFF
--- a/src/renderer/components/cesium/geometry-tool.ts
+++ b/src/renderer/components/cesium/geometry-tool.ts
@@ -265,7 +265,10 @@ class PolyTool extends ToolBase {
     }
 
     handleMouseMove(movement) {
-        this.moveLastPoint(movement.endPosition);
+        // Rendering on mouse move turned out to be a performance issue. Without this line a Polygon/Polyline will
+        // only be rendered on left mouse click when a point is actually added to the feature.
+
+        //this.moveLastPoint(movement.endPosition);
     }
 
     handleLeftDoubleClick(leftClick) {
@@ -317,16 +320,16 @@ class PolyTool extends ToolBase {
         this.reset();
     }
 
-    private moveLastPoint(position) {
-        if (!this.polylinePositions) {
-            return;
-        }
-        const cartesian = this.context.pickEllipsoid(position);
-        if (cartesian) {
-            this.updatePositions(cartesian);
-            this.hasRubberband = true;
-        }
-    }
+    // private moveLastPoint(position) {
+    //     if (!this.polylinePositions) {
+    //         return;
+    //     }
+    //     const cartesian = this.context.pickEllipsoid(position);
+    //     if (cartesian) {
+    //         this.updatePositions(cartesian);
+    //         this.hasRubberband = true;
+    //     }
+    // }
 
     private updatePositions(cartesian): boolean {
         const polylinePoint = this.context.cartesianWithHeightDelta(cartesian, polylineHeight);
@@ -400,7 +403,9 @@ class PolyTool extends ToolBase {
         this.polylineEntity = null;
         this.polygonEntity = null;
         this.hasRubberband = false;
-        this.context.removeAllToolEntities();
+        if(this.context) {
+            this.context.removeAllToolEntities();
+        }
     }
 
 }


### PR DESCRIPTION
This is one way to improve that tool.

The usability of the Polygons/Polylines Tool is hampered by a lag in mouse response times. That lag is caused by the usage of the mouse move event for displaying the latest to-be polyline when editing a poly feature. This pull request will remove that feature from the editing tool. The new point and the edge to the previous point will only be rendered after adding a point/node, which is triggered by a left mouse click event.