### PR TITLE
Simplified webAPIConfig

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,38 @@
 ## Version 2.1.0-dev.0
 
+* Simplified development configuration `./cate-config.js` (see template `./cate-config.template.js`). Instead of 
+  
+  ```javascript
+  module.exports = {  
+      webAPIConfig: {
+          servicePort: 9090,
+          serviceAddress: '',
+          serviceProtocol: 'http',
+          serviceFile: 'webapi-info.json',
+      },
+      // ...
+  };
+  ```
+  
+  you now write
+
+  ```javascript
+  module.exports = {  
+      webAPIConfig: {
+          serviceURL: 'http://localhost:9090',
+          serviceFile: 'webapi-info.json',
+      },
+      // ...
+  };
+  ```
+
 * Added icon for Sea Surface Salinity CCI ECV. 
+* Upgraded the following dependencies to recent versions:
+  * Electron 8.0.x 
+  * React 16.12.x 
+  * BlueprintJS 3.x
+  * Cesium 0.66+
+  * TypeScript 3.8+
 
 ## Version 2.0.0
 

--- a/cate-config.template.js
+++ b/cate-config.template.js
@@ -10,17 +10,9 @@ module.exports = {
      */
     webAPIConfig: {
         /**
-         * The port used by the Cate WebAPI service, or null if not used.
+         * The URL of the Cate Web API service.
          */
-        servicePort: 9090,
-        /**
-         * The address used by the Cate WebAPI service, use empty string to denote localhost (127.0.0.1)
-         */
-        serviceAddress: '',
-        /**
-         * The protocol used by the Cate WebAPI service, must be 'http' or 'https'.
-         */
-        serviceProtocol: 'http',
+        serviceURL: 'http://localhost:9090',
         /**
          * The file in which Cate WebAPI service stores its configuration while it is running.
          */

--- a/src/main/actions.ts
+++ b/src/main/actions.ts
@@ -306,16 +306,13 @@ export function getActions(configuration: Configuration) {
             click: () => {
                 const title = `About ${electron.app.getName()}`;
                 const message = `${electron.app.getName()}, version ${electron.app.getVersion()}`;
-                const webAPIConfig = configuration.get('webAPIConfig') || {
-                    protocol: 'http',
-                    serviceAddress: 'unknown.com'
-                };
+                const webAPIConfig = configuration.get('webAPIConfig') || {};
                 const user = configuration.get('user') || {name: process.env['USER']};
                 const detail = '' +
                                `Program: ${electron.app.getAppPath()}\n` +
                                `User: ${user.name}\n` +
                                `Data folder: ${getAppDataDir()}\n` +
-                               `Web API: ${getWebAPIRestUrl(webAPIConfig)}\n` +
+                               `Service URL: ${webAPIConfig.serviceURL || 'https://unknown.com'}\n` +
                                `CLI env: ${getCateDir() ? getCateDir() : '<unknown>'}\n` +
                                `Requires Cate Core ${CATE_WEBAPI_VERSION_RANGE}\n` +
                                '\n' +

--- a/src/main/appenv.spec.ts
+++ b/src/main/appenv.spec.ts
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import * as semver from 'semver';
-import { CATE_WEBAPI_VERSION_RANGE, getProxySettings, getSessionProxyConfig, isLocalWebAPIService } from './appenv';
-import { WebAPIConfig } from '../renderer/state';
+import { CATE_WEBAPI_VERSION_RANGE, getProxySettings, getSessionProxyConfig } from './appenv';
 
 describe('appenv', function () {
 
@@ -79,17 +78,5 @@ describe('appenv', function () {
                 proxyRules: 'http://ofsquid.dwd.de:8080;https://ofsquid.dwd.de:80;ws:ws.bc.com',
                 proxyBypassRules: '<local>;dev.virtualearth.net;dwd.de;*.foogle.com'
             });
-    });
-
-    it('implements isLocalWebAPIService() correctly', function () {
-
-        expect(isLocalWebAPIService({} as WebAPIConfig)).to.be.true;
-        expect(isLocalWebAPIService({serviceAddress: ''} as WebAPIConfig)).to.be.true;
-        expect(isLocalWebAPIService({serviceAddress: 'localhost'} as WebAPIConfig)).to.be.true;
-        expect(isLocalWebAPIService({serviceAddress: '::1'} as WebAPIConfig)).to.be.true;
-        expect(isLocalWebAPIService({serviceAddress: '127.0.0.1'} as WebAPIConfig)).to.be.true;
-
-        expect(isLocalWebAPIService({serviceAddress: '192.171.139.57'} as WebAPIConfig)).to.be.false;
-        expect(isLocalWebAPIService({serviceAddress: 'cate-webapi.192.171.139.57.nip.io'} as WebAPIConfig)).to.be.false;
     });
 });

--- a/src/renderer/selectors.ts
+++ b/src/renderer/selectors.ts
@@ -92,49 +92,34 @@ export const mplWebSocketUrlSelector = createSelector(
 );
 
 function getRestUrl(webAPIConfig: WebAPIConfig): string {
-    const protocol = getWebAPIHttpServiceProtocol(webAPIConfig);
-    const addressAndPort = getWebAPIAddressAndPort(webAPIConfig);
-    return `${protocol}://${addressAndPort}/`;
+    return makeURL(webAPIConfig.serviceURL, false, '/');
 }
 
 function getAPIWebSocketsUrl(webAPIConfig: WebAPIConfig): string {
-    const protocol = getWebAPIWebSocketServiceProtocol(webAPIConfig);
-    const addressAndPort = getWebAPIAddressAndPort(webAPIConfig);
-    return `${protocol}://${addressAndPort}/api`;
+    return makeURL(webAPIConfig.serviceURL, true, 'api');
 }
 
 function getMPLWebSocketsUrl(webAPIConfig: WebAPIConfig): string {
-    const protocol = getWebAPIWebSocketServiceProtocol(webAPIConfig);
-    const addressAndPort = getWebAPIAddressAndPort(webAPIConfig);
-    return `${protocol}://${addressAndPort}/mpl/figures/`;
+    return makeURL(webAPIConfig.serviceURL, true, 'mpl/figures/');
 }
 
-function isLocalWebAPIService(webAPIConfig: WebAPIConfig) {
-    const serviceAddress = webAPIConfig.serviceAddress;
-    return !serviceAddress
-           || serviceAddress === ''
-           || serviceAddress === 'localhost'
-           || serviceAddress === '127.0.0.1'
-           || serviceAddress === '::1';
-}
-
-function getWebAPIHttpServiceProtocol(webAPIConfig: WebAPIConfig): 'http' | 'https' {
-    return webAPIConfig.serviceProtocol || 'http';
-}
-
-function getWebAPIWebSocketServiceProtocol(webAPIConfig: WebAPIConfig): 'wss' | 'ws' {
-    const protocol = getWebAPIHttpServiceProtocol(webAPIConfig);
-    return protocol === 'https' ? 'wss' : 'ws'
-}
-
-function getWebAPIAddressAndPort(webAPIConfig: WebAPIConfig): string {
-    const serviceAddress = webAPIConfig.serviceAddress || 'localhost';
-    if (typeof (webAPIConfig.servicePort) === 'number') {
-        return `${serviceAddress}:${webAPIConfig.servicePort}`;
+function makeURL(url: string, ws: boolean, path: string): string {
+    const _url = new URL(url);
+    const protocol = ws ? (_url.protocol === 'https:' ? 'wss:' : 'ws:') : _url.protocol;
+    const pathname = _url.pathname;
+    let newUrl = `${protocol}//${ _url.host}`;
+    if (pathname && pathname !== '/') {
+        newUrl += pathname
     }
-    return serviceAddress;
+    if (path) {
+        if (!(path.startsWith('/') || newUrl.endsWith('/'))) {
+            newUrl += '/';
+        }
+        newUrl += path
+    }
+    console.log(`makeUrl: [${newUrl}]`);
+    return newUrl;
 }
-
 
 export const backendConfigAPISelector = createSelector(
     webAPIClientSelector,

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -53,9 +53,7 @@ export interface AppConfigState {
 
 export interface WebAPIConfig {
     // Values read by main.ts from ./cate-config.js
-    servicePort?: number | null;
-    serviceAddress: string;
-    serviceProtocol?: 'http' | 'https';
+    serviceURL: string;
     serviceFile?: string;
     processOptions?: Object;
 }

--- a/src/renderer/webapi/apis/AuthAPI.ts
+++ b/src/renderer/webapi/apis/AuthAPI.ts
@@ -1,15 +1,10 @@
 import { WebAPIConfig } from '../../state';
 
-const CATE_HUB_DOMAIN = 'catehub.192.171.139.57.nip.io';
-
-const CATE_SERVICE_PROTOCOL = 'https';
-const CATE_SERVICE_ADDRESS = CATE_HUB_DOMAIN + '/user/{username}';
-const CATE_SERVICE_PORT = null;
-
-const CATE_HUB_API_URL = CATE_SERVICE_PROTOCOL + '://' + CATE_HUB_DOMAIN + '/hub/api/';
-const CATE_HUB_TOKEN_URL = CATE_HUB_API_URL + 'authorizations/token';
-const CATE_HUB_USER_SERVER_URL = CATE_HUB_API_URL + 'users/{username}/server';
-const CATE_HUB_USER_URL = CATE_HUB_API_URL + 'users/{username}';
+const CATE_HUB_SERVER_BASE = 'https://catehub.192.171.139.57.nip.io';
+const CATE_SERVICE_URL = CATE_HUB_SERVER_BASE + '/user/{username}';
+const CATE_HUB_TOKEN_URL = CATE_HUB_SERVER_BASE + '/hub/api/authorizations/token';
+const CATE_HUB_USER_SERVER_URL = CATE_HUB_SERVER_BASE + '/hub/api/users/{username}/server';
+const CATE_HUB_USER_URL = CATE_HUB_SERVER_BASE + '/hub/api/users/{username}';
 
 export interface AuthInfo {
     token: string;
@@ -34,9 +29,7 @@ export class AuthAPI {
     // noinspection JSMethodCanBeStatic
     getWebAPIConfig(username: string): WebAPIConfig {
         return {
-            serviceProtocol: CATE_SERVICE_PROTOCOL,
-            serviceAddress: CATE_SERVICE_ADDRESS.replace('{username}', username),
-            servicePort: CATE_SERVICE_PORT,
+            serviceURL: new URL(CATE_SERVICE_URL).toString(),
         };
     }
 


### PR DESCRIPTION
* Simplified development configuration `./cate-config.js` (see template `./cate-config.template.js`).
  Instead of 
  
  ```javascript
  module.exports = {  
      webAPIConfig: {
          servicePort: 9090,
          serviceAddress: '',
          serviceProtocol: 'http',
          serviceFile: 'webapi-info.json',
      },
      // ...
  };
  ```
  
  you now write

  ```javascript
  module.exports = {  
      webAPIConfig: {
          serviceURL: 'http://localhost:9090',
          serviceFile: 'webapi-info.json',
      },
      // ...
  };
  ```